### PR TITLE
git-bubbles

### DIFF
--- a/git-bubbles
+++ b/git-bubbles
@@ -1,0 +1,78 @@
+#!/bin/bash -e
+
+function log {
+	git --no-pager log --oneline --decorate --graph "$@"
+}
+
+filter_pattern=$(git config bubbles.pattern || echo "--")
+mine=$(git config bubbles.remote-name || echo "origin")
+
+commit=$(git find-pushable-head "$filter_pattern")
+branch_name=$(git rev-parse --symbolic-full-name HEAD | sed 's-^refs/heads/--')
+
+push_command="git push $mine $commit:$branch_name --force"
+
+function print_log {
+	if [[ ! $(git rev-parse HEAD) =~ ^$commit ]]; then
+		log "${commit}..HEAD"
+		echo "--------------------------------------------------"
+	fi
+	log "HEAD@{u}..$commit"
+}
+
+function announce {
+	echo "$*"
+	"$@"
+}
+
+function print_status {
+	local command=$1
+	missing_branch=$(git rev-parse "$mine/$branch_name" >/dev/null 2>/dev/null || echo "1")
+
+	if [ "$missing_branch" == "1" ]; then
+		echo "Branch $branch_name not yet pushed on ${mine}. To create it:"
+		echo "git push $mine HEAD"
+	else
+		diff_stat=$(git diff --stat "$mine/$branch_name..$commit" 2>/dev/null | wc -c)
+		log_stat=$(git --no-pager log --oneline "$mine/$branch_name..$commit" 2>/dev/null | wc -l)
+		if [ "$diff_stat" != "0" ]; then
+			if [ "$command" == "execute" ]; then
+				$push_command
+			else
+				announce git diff -b -M "$mine/$branch_name..$commit" --stat
+
+				echo ""
+				echo "$push_command"
+			fi
+		elif [ "$log_stat" != "0" ]; then
+			echo "No diff but history diverged."
+			echo ""
+			if [ "$command" == "execute" ]; then
+				$push_command
+			else
+				echo "$push_command"
+			fi
+		else
+			echo "Nothing to push. We're good!"
+		fi
+	fi
+}
+
+if [ "$1" == "push" ]; then
+	print_status execute
+
+elif [ "$1" == "diff" ]; then
+	shift 1
+	if [ "$diff_stat" != "0" ]; then
+		announce git diff -b -M "$mine/$branch_name..$commit" "$@"
+	fi
+
+elif [ "$1" == "content" ]; then
+	shift 1
+	git diff --stat --patch -w -M "HEAD@{u}..$commit" "$@"
+
+else
+	print_log
+	echo ""
+	print_status
+fi

--- a/git-find-pushable-head
+++ b/git-find-pushable-head
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+pattern=$1
+git log --oneline "HEAD@{u}.." | sed "/${pattern}/d" | head -1 | cut -d" " -f1


### PR DESCRIPTION
### git-bubbles

Outil de gestion de branches pour pull requests.
#### Usage

`git bubbles`

Liste les commits et affiche ceux qui seront poussés sur le dépôt distant. Une ligne sépare les commits partagés de ceux qui restent en local. Le filtre par défaut est `--`, il est configurable (cf `bubbles.pattern`).
Affiche également une vue synthétique de la différence entre la branche courante et la remote déjà poussée.

Exemple :

```
$ git bubbles
* b1aae76 (HEAD, reloadable-http-config) --HACK-- Tweak HTTP server config
* bdc9adf --HACK-- Use /tmp for cache files
--------------------------------------------------
* 3d9805d Configuration files can now be reloaded in dev mode
* c382b47 Upgrade to HTTPd 4.0

git diff -b -M ptitfred/reloadable-http-config..3d9805d --stat
 src/main/ruby/lib/configuration.rb |  22 ++++++++++++++++++++++++++++++
 build.xml                          |   2 +-
 2 files changed, 24 insertions(+), 2 deletions(-)

git push mine 3d9805d:reloadable-http-config --force
```

`git bubbles diff`

Affiche la différence entre la branche courante et la remote déjà poussée : cela correspond aux modifications que l'on veut incorporer dans la branche, par exemple suite à de la revue de code

`git bubbles push`

Effectue le git push --force avec uniquement les commits qui passent le filtre.

`git bubbles content`

Inspecte la diff de la branche (uniquement les commits qui passent le filtre).
#### Configuration

`bubbles.remote-name` text => nom de la remote où chercher les branches synchronisées
`bubbles.pattern` text => filtre utilisé pour exclure des commits (par exemple des commits que l'on ne veut pas partager, de la configuration, des patchs pour les tests, pour s'adapter à l'architecture, pour supporter une bibliothèque tierce...)
