### PR TITLE
Package some scripts of this repository in a Nix derivation

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,26 +1,31 @@
 { stdenv, lib, fetchFromGitHub, git, gnused }:
 
-stdenv.mkDerivation rec {
-  name = "git-bubbles";
+let packageScript = script: buildInputs: description:
+      stdenv.mkDerivation rec {
+        name = "posix-toolbox-" + script;
 
-  src = ./..;
+        src = ./..;
 
-  buildInputs = [ git gnused ];
+        inherit buildInputs;
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp $src/git-bubbles $out/bin/git-bubbles
-  '';
-
-  postFixup =
-    let runtimePath = lib.makeBinPath buildInputs;
-     in ''
-          sed -i "2 i export PATH=${runtimePath}:\$PATH" $out/bin/git-bubbles
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src/${script} $out/bin/${script}
         '';
 
-  meta = {
-    homepage = "https://github.com/ptitfred/posix-toolbox";
-    description = "A git script to handle pull requests";
-    license = lib.licenses.mit;
-  };
-}
+        postFixup =
+          let runtimePath = lib.makeBinPath buildInputs;
+           in ''
+                sed -i "2 i export PATH=${runtimePath}:\$PATH" $out/bin/${script}
+              '';
+
+        meta = {
+          homepage = "https://github.com/ptitfred/posix-toolbox";
+          inherit description;
+          license = lib.licenses.mit;
+        };
+      };
+
+in { git-bubbles      = packageScript "git-bubbles"      [ git gnused ] "A git script to handle pull requests";
+     git-checkout-log = packageScript "git-checkout-log" [ git ]        "A git script to browser reflog and follow checkouts";
+   }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, git, gnused }:
+
+stdenv.mkDerivation rec {
+  name = "git-bubbles";
+
+  src = ./..;
+
+  buildInputs = [ git gnused ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/git-bubbles $out/bin/git-bubbles
+  '';
+
+  postFixup =
+    let runtimePath = lib.makeBinPath buildInputs;
+     in ''
+          sed -i "2 i export PATH=${runtimePath}:\$PATH" $out/bin/git-bubbles
+        '';
+
+  meta = {
+    homepage = "https://github.com/ptitfred/posix-toolbox";
+    description = "A git script to handle pull requests";
+    license = lib.licenses.mit;
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,31 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, git, gnused }:
+{ callPackage, stdenv, lib, git, gnused }:
 
-let packageScript = script: buildInputs: description:
-      stdenv.mkDerivation rec {
-        name = "posix-toolbox-" + script;
-
-        src = ./..;
-
-        inherit buildInputs;
-
-        installPhase = ''
-          mkdir -p $out/bin
-          cp $src/${script} $out/bin/${script}
-        '';
-
-        postFixup =
-          let runtimePath = lib.makeBinPath buildInputs;
-           in ''
-                sed -i "2 i export PATH=${runtimePath}:\$PATH" $out/bin/${script}
-              '';
-
-        meta = {
-          homepage = "https://github.com/ptitfred/posix-toolbox";
-          inherit description;
-          license = lib.licenses.mit;
-        };
-      };
-
+let packageScript = callPackage ./package.nix {};
 in { git-bubbles      = packageScript "git-bubbles"      [ git gnused ] "A git script to handle pull requests";
      git-checkout-log = packageScript "git-checkout-log" [ git ]        "A git script to browser reflog and follow checkouts";
    }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,22 +1,19 @@
-{ stdenv, lib }:
+{ stdenv, lib, makeWrapper }:
 
-script: buildInputs: description:
+script: inputs: description:
   stdenv.mkDerivation rec {
     name = "posix-toolbox-" + script;
 
     src = ./..;
 
-    inherit buildInputs;
+    buildInputs = inputs ++ [ makeWrapper ] ;
 
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $src/${script} $out/bin/${script}
-    '';
-
-    postFixup =
-      let runtimePath = lib.makeBinPath buildInputs;
+    installPhase =
+      let runtimePath = lib.makeBinPath inputs;
        in ''
-            sed -i "2 i export PATH=${runtimePath}:\$PATH" $out/bin/${script}
+            mkdir -p $out/bin
+            cp $src/${script} $out/bin/${script}
+            wrapProgram $out/bin/${script} --prefix PATH : "${runtimePath}"
           '';
 
     meta = {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib }:
+
+script: buildInputs: description:
+  stdenv.mkDerivation rec {
+    name = "posix-toolbox-" + script;
+
+    src = ./..;
+
+    inherit buildInputs;
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $src/${script} $out/bin/${script}
+    '';
+
+    postFixup =
+      let runtimePath = lib.makeBinPath buildInputs;
+       in ''
+            sed -i "2 i export PATH=${runtimePath}:\$PATH" $out/bin/${script}
+          '';
+
+    meta = {
+      homepage = "https://github.com/ptitfred/posix-toolbox";
+      inherit description;
+      license = lib.licenses.mit;
+    };
+  }

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,0 +1,2 @@
+{ pkgs ? import <nixpkgs> {}
+}: pkgs.callPackage ./default.nix {}


### PR DESCRIPTION
Let's make some scripts packaged for Nix.

If you want to add it via an overlay, you can use this Nix expression:

```nix
self: super:

let fetchPackage = owner: repo: path: rev: sha256:
      self.callPackage (self.fetchFromGitHub { inherit owner repo rev sha256; } + path) {};
in {
     personal = {
        posix-toolbox = fetchPackage "ptitfred" "posix-toolbox" "/nix/default.nix"
          "2c4b1696e285daefe2bc7bf9336562bcb83b5da5" "10dps0rr0pv43xlkd1hiafhsallhji6ww3vca5cmq044m5zpx3di";
     };
   }
```

I personally have it under `$HOME/.config/nixpkgs/overlays/personal.nix` and this notably let me have those script in my path via home-manager:

```nix
{ pkgs, ... }:

{
  programs.git = {
    enable = true;
    userName = "Frédéric Menou";
    userEmail = "frederic.menou@gmail.com";
  };

  home.packages = with pkgs; [
    personal.posix-toolbox.git-bubbles
    personal.posix-toolbox.git-checkout-log
  ];
}
```