### PR TITLE
LS_COLORS shared sourceable script

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,4 +3,5 @@
 let packageScript = callPackage ./package.nix {};
 in { git-bubbles      = packageScript "git-bubbles"      [ git gnused ] "A git script to handle pull requests";
      git-checkout-log = packageScript "git-checkout-log" [ git ]        "A git script to browser reflog and follow checkouts";
+     ls-colors = callPackage ./ls-colors.nix {};
    }

--- a/nix/ls-colors.nix
+++ b/nix/ls-colors.nix
@@ -1,0 +1,20 @@
+{ stdenv, coreutils, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "ls-colors";
+
+  src = fetchFromGitHub {
+    owner = "trapd00r";
+    repo = "LS_COLORS";
+    rev = "e91cc9cc69f6c4780f03b121bc633569742de7cd";
+    sha256 = "1i2pc9k1g79wvdq3w2h3ikp3s2myalcvwin2l6gmyhz5cn0xjfg8";
+  };
+
+  buildInputs = [ coreutils ];
+
+  installPhase = ''
+    mkdir -p $out/share/ls-colors
+    dircolors -b $src/LS_COLORS > $out/share/ls-colors/bash.sh
+    dircolors -c $src/LS_COLORS > $out/share/ls-colors/csh.sh
+  '';
+}


### PR DESCRIPTION
Assuming you install ls-colors, you could then patch your bash
configuration this way:

```bash
source $HOME/.nix-profile/share/ls-colors/bash.sh
```

I do this via home-manager with `programs.bash.initExtra`.

It's also available for cshell via `$HOME/.nix-profile/share/ls-colors/csh.sh`.