### PR TITLE
Cleanup

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, stdenv, lib, coreutils, findutils, gawk, git, gnugrep, gnused, less, lsof, psmisc, utillinux }:
+{ callPackage, coreutils, findutils, gawk, git, gnugrep, gnused, less, lsof, psmisc, utillinux }:
 
 let packageScript = callPackage ./package.nix {};
     git-authors      = packageScript "git-authors"      [ coreutils findutils git gnused  ] "A git script to list committers other a commit range";

--- a/shell.nix
+++ b/shell.nix
@@ -3,5 +3,5 @@
 
 let aspell = pkgs.aspellWithDicts (d: [d.en]);
  in pkgs.mkShell {
-      buildInputs = [ aspell pkgs.shellcheck ];
+      buildInputs = [ aspell pkgs.git pkgs.shellcheck ];
     }

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -2,17 +2,4 @@
 
 set -e
 
-shellcheck \
-  src/git-authors \
-  src/git-bubbles \
-  src/git-checkout-log \
-  src/git-prd \
-  src/git-pwd \
-  src/git-rm-others \
-  src/git-search \
-  src/git-short \
-  src/git-std-init \
-  src/prd \
-  src/repeat \
-  src/short-path \
-  src/wait-tcp
+shellcheck $(git ls-files src/)


### PR DESCRIPTION
- Apply [nix-linter](https://github.com/Synthetica9/nix-linter) advices.
- Use git to enumerate bash scripts to lint as we now have them in a dedicated directory.