### PR TITLE
Configuration options for git-bubbles

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ The `your-home.nix` file might contain:
 {
   ptitfred.posix-toolbox.enable = true;
 
+  # Options for the git-bubbles script:
+  ptitfred.posix-toolbox.git-bubbles.remote-name = "some-remote-name";
+  ptitfred.posix-toolbox.git-bubbles.pattern = "---";
+
   # You might have to enable git though:
   programs.git.enable = true;
 

--- a/tests/hm-module.nix
+++ b/tests/hm-module.nix
@@ -14,4 +14,7 @@
 
   # This is how you enable posix-toolbox features (depends on bash and git being active):
   ptitfred.posix-toolbox.enable = true;
+
+  # Example configuration for git-bubbles:
+  ptitfred.posix-toolbox.git-bubbles.remote-name = "mine";
 }


### PR DESCRIPTION
The home-manager module now supports configuration options of the git-bubbles script.

Fixes #45.