### PR TITLE
ls-colors: drop csh support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728193676,
-        "narHash": "sha256-PbDWAIjKJdlVg+qQRhzdSor04bAPApDqIv2DofTyynk=",
+        "lastModified": 1729044727,
+        "narHash": "sha256-GKJjtPY+SXfLF/yTN7M2cAnQB6RERFKnQhD8UvPSf3M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
+        "rev": "dc2e0028d274394f73653c7c90cc63edbb696be1",
         "type": "github"
       },
       "original": {

--- a/src/ls-colors.nix
+++ b/src/ls-colors.nix
@@ -8,5 +8,4 @@ runCommand "posix-toolbox-ls-colors"
   ''
     mkdir -p $out/share/ls-colors
     dircolors -b $src/LS_COLORS > $out/share/ls-colors/bash.sh
-    dircolors -c $src/LS_COLORS > $out/share/ls-colors/csh.sh
   ''


### PR DESCRIPTION
I don't need it. If you do, feel free to contribute it back with a proper support in the home-manager module.