### PR TITLE
Readme: CI badge irrelevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # posix-toolbox
 
-![tests](https://github.com/ptitfred/posix-toolbox/workflows/tests/badge.svg)
-
 ## About
 
 A collection of Unix scripts to ease my life. Mostly around git.


### PR DESCRIPTION
CI has been moved to garnix, the badge is not up-to-date.