### PR TITLE
home-manager: option to add all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Other scripts I used to use or are used here:
 - [repeat](src/repeat/repeat.sh), a script to repeat a command some times
 - [short-path](src/short-path/short-path.sh), a script to abbreviate every directory unless the last part of a path
 
+Those scripts can be installed by the home-manager module with the `ptitfred.posix-toolbox.extras` flag.
+
 * * *
 
 Copyright &copy; 2010-, Frédéric Menou and Céline Louvet. Licensed under [MIT License].

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -11,12 +11,42 @@ let cfg = config.ptitfred.posix-toolbox;
       git-tree
     ];
 
-    tools-packages = [ posix-toolbox.wait-tcp ];
+    git-extra-packages = with posix-toolbox; lib.lists.optional config.programs.git.enable [
+      git-authors
+      git-prd
+      git-pwd
+      git-rm-others
+      git-search
+      git-short
+      git-std-init
+    ];
 
-    packages =
+    tools-packages = with posix-toolbox; [
+      wait-tcp
+    ];
+
+    tools-extra-packages = with posix-toolbox; [
+      repeat
+    ];
+
+    base-packages =
       lib.lists.flatten [
         git-packages
         tools-packages
+      ];
+
+    extra-packages =
+      lib.lists.optional cfg.extras (
+        lib.lists.flatten [
+          git-extra-packages
+          tools-extra-packages
+        ]
+      );
+
+    packages =
+      lib.lists.flatten [
+        base-packages
+        extra-packages
       ];
 
     gitBashInitExtra =
@@ -54,6 +84,8 @@ in
         check-threshold  = helpers.mkOptionalInt  "check-threshold";
         shorten          = helpers.mkOptionalInt  "shorten";
       };
+
+      extras = lib.mkEnableOption "extra posix-toolbox packages";
     };
   };
 

--- a/tests/hm-module.nix
+++ b/tests/hm-module.nix
@@ -24,4 +24,6 @@
     check-threshold  = 2;
     shorten          = 2;
   };
+
+  ptitfred.posix-toolbox.extras = true;
 }


### PR DESCRIPTION
The home-manager module installs a subset of packages (depending on git or bash being enabled). This fixes it by adding an option to add the other scripts:

```nix
{}:

{
  ptitfred.posix-toolbox.extras = true;
}
```

I don't use them directly any more but this module should be able to install them if needed.