### PR TITLE
nix-linter: package all dependencies

### DIFF
--- a/src/nix-linter.nix
+++ b/src/nix-linter.nix
@@ -1,11 +1,11 @@
 { excludedPaths
-, lib, pinned-nix-linter, writeShellApplication }:
+, findutils, lib, pinned-nix-linter, writeShellApplication }:
 
 let toFindExcludedPath = path: "! -path \"$src/${path}\"";
     excludedPathsStr = lib.strings.concatMapStringsSep " " toFindExcludedPath excludedPaths;
  in writeShellApplication {
       name = "nix-linter";
-      runtimeInputs = [ pinned-nix-linter ];
+      runtimeInputs = [ findutils pinned-nix-linter ];
       text = ''
         set -e
 


### PR DESCRIPTION
Explicitly package all dependencies to make it work in raw shells (notably: systemd services).