### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732466619,
-        "narHash": "sha256-T1e5oceypZu3Q8vzICjv1X/sGs9XfJRMW5OuXHgpB3c=",
+        "lastModified": 1733572789,
+        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f3111f62a23451114433888902a55cf0692b408d",
+        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732981179,
-        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
+        "lastModified": 1733550349,
+        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
+        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'home-manager':
    'github:nix-community/home-manager/f3111f62a23451114433888902a55cf0692b408d' (2024-11-24)
  → 'github:nix-community/home-manager/62d536255879be574ebfe9b87c4ac194febf47c5' (2024-12-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/62c435d93bf046a5396f3016472e8f7c8e2aed65' (2024-11-30)
  → 'github:nixos/nixpkgs/b681065d0919f7eb5309a93cea2cfa84dec9aa88' (2024-12-03)
```
