### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744117652,
-        "narHash": "sha256-t7dFCDl4vIOOUMhEZnJF15aAzkpaup9x4ZRGToDFYWI=",
+        "lastModified": 1744743431,
+        "narHash": "sha256-iyn/WBYDc7OtjSawbegINDe/gIkok888kQxk3aVnkgg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b4e98224ad1336751a2ac7493967a4c9f6d9cb3f",
+        "rev": "c61bfe3ae692f42ce688b5865fac9e0de58e1387",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744168086,
-        "narHash": "sha256-S9M4HddBCxbbX1CKSyDYgZ8NCVyHcbKnBfoUXeRu2jQ=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "60e405b241edb6f0573f3d9f944617fe33ac4a73",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
     "trapd00r-ls-colors": {
       "flake": false,
       "locked": {
-        "lastModified": 1734720078,
-        "narHash": "sha256-ePs7UlgQqh3ptRXUNlY/BDa/1aH9q3dGa3h0or/e6Kk=",
+        "lastModified": 1744902673,
+        "narHash": "sha256-6kKehugUwNZe/J2n82HfHgnNbvBZj5oYHD6IWD/AxTk=",
         "owner": "trapd00r",
         "repo": "LS_COLORS",
-        "rev": "81e2ebcdc2ed815d17db962055645ccf2125560c",
+        "rev": "91516300c442cbf4592dec70972e2c878e5eba88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'home-manager':
    'github:nix-community/home-manager/b4e98224ad1336751a2ac7493967a4c9f6d9cb3f' (2025-04-08)
  → 'github:nix-community/home-manager/c61bfe3ae692f42ce688b5865fac9e0de58e1387' (2025-04-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/60e405b241edb6f0573f3d9f944617fe33ac4a73' (2025-04-09)
  → 'github:nixos/nixpkgs/26d499fc9f1d567283d5d56fcf367edd815dba1d' (2025-04-12)
• Updated input 'trapd00r-ls-colors':
    'github:trapd00r/LS_COLORS/81e2ebcdc2ed815d17db962055645ccf2125560c' (2024-12-20)
  → 'github:trapd00r/LS_COLORS/91516300c442cbf4592dec70972e2c878e5eba88' (2025-04-17)
```
