### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781319724,
-        "narHash": "sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M=",
+        "lastModified": 1781981105,
+        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8355f0a16b2dbb06a97959a918af5b239bbe05ae",
+        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781216227,
-        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
+        "lastModified": 1781808408,
+        "narHash": "sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8+l4Jj2e1Q0r3w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "rev": "e8210c649915deed7080033cdbabcc19e40bb899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'home-manager':
    'github:nix-community/home-manager/8355f0a16b2dbb06a97959a918af5b239bbe05ae?narHash=sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M%3D' (2026-06-13)
  → 'github:nix-community/home-manager/7bfff44b465909f69a442701293bc0badcf476dc?narHash=sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg%2BTNl0CjxS3UQJKlw%3D' (2026-06-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a0374025a863d007d98e3297f6aa46cc3141c2f0?narHash=sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE%3D' (2026-06-11)
  → 'github:nixos/nixpkgs/e8210c649915deed7080033cdbabcc19e40bb899?narHash=sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8%2Bl4Jj2e1Q0r3w%3D' (2026-06-18)
```
