### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781981105,
-        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
+        "lastModified": 1788642154,
+        "narHash": "sha256-sPpQFVaFTDqO/4vvCAhuAhqTgqN/ygu+9eJcs5eB0js=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
+        "rev": "fd0956c99c41ae3c13a73a638f1f7e963aebc4ab",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781808408,
-        "narHash": "sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8+l4Jj2e1Q0r3w=",
+        "lastModified": 1788690626,
+        "narHash": "sha256-+v4I4LawmRD/mVxO7QIAerRrCkElp3YImzWkkUnvOTg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8210c649915deed7080033cdbabcc19e40bb899",
+        "rev": "c25784012c9982bca5b3e0de87e90bbdac8927d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'home-manager':
    'github:nix-community/home-manager/7bfff44b465909f69a442701293bc0badcf476dc?narHash=sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg%2BTNl0CjxS3UQJKlw%3D' (2026-06-20)
  → 'github:nix-community/home-manager/868d0a692de703c2de98fab61968e4e310b7c28e?narHash=sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck%3D' (2026-06-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e8210c649915deed7080033cdbabcc19e40bb899?narHash=sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8%2Bl4Jj2e1Q0r3w%3D' (2026-06-18)
  → 'github:nixos/nixpkgs/95ca1e203c0750115fd4a6f17d5a245dfe6b1edd?narHash=sha256-JC9PjqKYG9ve5U8aDOLQipp3%2BKLANBHUvGdLZlxzdKI%3D' (2026-06-30)
```
